### PR TITLE
fix: fixes and operator parser fn in query parsing

### DIFF
--- a/lib/utils/parse-query.js
+++ b/lib/utils/parse-query.js
@@ -63,14 +63,19 @@ function $and(value, esQuery, idProp) {
     .filter((parsed) => !!parsed)
     .forEach((parsed) => {
       Object.keys(parsed).forEach((section) => {
-        esQuery[section] = esQuery[section] || [];
-        esQuery[section].push(...parsed[section]);
+        // NOTE - Added separate handling for non array sections
+        if (Array.isArray(parsed[section])) {
+          esQuery[section] = esQuery[section] || [];
+          esQuery[section].push(...parsed[section]);
+        } else {
+          esQuery[section] = esQuery[section] || [];
+          esQuery[section] = parsed[section];
+        }
       });
     });
 
   return esQuery;
 }
-
 function $sqs(value, esQuery) {
   if (value === null || value === undefined) {
     return esQuery;

--- a/lib/utils/parse-query.js
+++ b/lib/utils/parse-query.js
@@ -76,6 +76,7 @@ function $and(value, esQuery, idProp) {
 
   return esQuery;
 }
+
 function $sqs(value, esQuery) {
   if (value === null || value === undefined) {
     return esQuery;

--- a/lib/utils/parse-query.js
+++ b/lib/utils/parse-query.js
@@ -55,6 +55,19 @@ function $all(value, esQuery) {
   return esQuery;
 }
 
+/**
+ * @link https://github.com/feathersjs-ecosystem/feathers-elasticsearch/pull/16/files
+ * Here $and was implemented for supporting array datatypes and not for parsing of es queries.
+ * This is okay when we do not have nested queries.
+ * However, when we have nested queries, we need to parse them and merge them into the esQuery.
+ * When nested queries are present, like $and: [{ $or: [...] }, { $or: [...] }], we cannot simply merge them.
+ * We need to parse and maintain the structure of the query.
+ * This is why we need to handle $and separately.
+ * This function merges the parsed queries into the esQuery, maintaining the structure.
+ * It handles both simple queries and nested queries, ensuring that the final esQuery is correctly structured.
+ * It also handles the case where a parsed query has a 'should' clause, which needs special handling (OR logic).
+ * Everything else can be merged directly for AND logic.
+ */
 function $and(value, esQuery, idProp) {
   validateType(value, '$and', 'array');
 
@@ -62,16 +75,24 @@ function $and(value, esQuery, idProp) {
     .map((subQuery) => parseQuery(subQuery, idProp))
     .filter((parsed) => !!parsed)
     .forEach((parsed) => {
-      Object.keys(parsed).forEach((section) => {
-        // NOTE - Added separate handling for non array sections
-        if (Array.isArray(parsed[section])) {
+      // If the parsed query has 'should' clause, it needs special handling (OR logic)
+      // Everything else can be merged directly for AND logic
+      if (parsed.should) {
+        // Wrap OR-type queries in bool and add to must
+        esQuery.must = esQuery.must || [];
+        esQuery.must.push({ bool: parsed });
+      } else {
+        // Direct merge for AND-compatible sections
+        Object.keys(parsed).forEach((section) => {
           esQuery[section] = esQuery[section] || [];
-          esQuery[section].push(...parsed[section]);
-        } else {
-          esQuery[section] = esQuery[section] || [];
-          esQuery[section] = parsed[section];
-        }
-      });
+
+          if (Array.isArray(parsed[section])) {
+            esQuery[section].push(...parsed[section]);
+          } else {
+            esQuery[section].push(parsed[section]);
+          }
+        });
+      }
     });
 
   return esQuery;

--- a/test/utils/parse-query.js
+++ b/test/utils/parse-query.js
@@ -293,6 +293,120 @@ module.exports = function parseQueryTests() {
       expect(parseQuery(query, '_id')).to.deep.equal(expectedResult);
     });
 
+    it('should return "bool" query for $and with $or inside', () => {
+      const query = {
+        $and: [
+          { tags: 'javascript' },
+          { age: { $in: [25, 26] } },
+          { $or: [{ tags: 'legend' }, { tags: 'nodejs' }] },
+          { age: { $nin: [23, 24] } },
+        ],
+        name: 'Doug',
+      };
+
+      const expectedResult = {
+        filter: [
+          { term: { tags: 'javascript' } },
+          { terms: { age: [25, 26] } },
+          { term: { name: 'Doug' } },
+        ],
+        must: [
+          {
+            bool: {
+              should: [
+                { bool: { filter: [{ term: { tags: 'legend' } }] } },
+                { bool: { filter: [{ term: { tags: 'nodejs' } }] } },
+              ],
+              minimum_should_match: 1,
+            },
+          },
+        ],
+        must_not: [{ terms: { age: [23, 24] } }],
+      };
+
+      expect(parseQuery(query, '_id')).to.deep.equal(expectedResult);
+    });
+
+    it('should return "bool" query for $or with $and inside', () => {
+      const query = {
+        $or: [
+          { tags: 'javascript' },
+          { $and: [{ tags: 'legend' }, { tags: 'nodejs' }] },
+          { age: { $nin: [23, 24] } },
+          { age: { $in: [25, 26] } },
+        ],
+        name: 'Doug',
+      };
+
+      const expectedResult = {
+        should: [
+          {
+            bool: {
+              filter: [{ term: { tags: 'javascript' } }],
+            },
+          },
+          {
+            bool: {
+              filter: [{ term: { tags: 'legend' } }, { term: { tags: 'nodejs' } }],
+            },
+          },
+          {
+            bool: {
+              must_not: [{ terms: { age: [23, 24] } }],
+            },
+          },
+          {
+            bool: {
+              filter: [{ terms: { age: [25, 26] } }],
+            },
+          },
+        ],
+        minimum_should_match: 1,
+        filter: [{ term: { name: 'Doug' } }],
+      };
+
+      expect(parseQuery(query, '_id')).to.deep.equal(expectedResult);
+    });
+
+    it('should return "must" query for multiple $or nested inside $and', () => {
+      const query = {
+        $and: [
+          { $or: [{ tags: 'javascript' }, { tags: 'nodejs' }] },
+          { $or: [{ tags: 'legend' }, { tags: 'react' }] },
+          { age: { $nin: [23, 24] } },
+          { age: { $in: [25, 26] } },
+        ],
+        name: 'Doug',
+      };
+
+      const expectedResult = {
+        must: [
+          {
+            bool: {
+              should: [
+                { bool: { filter: [{ term: { tags: 'javascript' } }] } },
+                { bool: { filter: [{ term: { tags: 'nodejs' } }] } },
+              ],
+              minimum_should_match: 1,
+            },
+          },
+          {
+            bool: {
+              should: [
+                { bool: { filter: [{ term: { tags: 'legend' } }] } },
+                { bool: { filter: [{ term: { tags: 'react' } }] } },
+              ],
+              minimum_should_match: 1,
+            },
+          },
+        ],
+        filter: [{ terms: { age: [25, 26] } }, { term: { name: 'Doug' } }],
+        must_not: [{ terms: { age: [23, 24] } }],
+      };
+
+      expect(parseQuery(query, '_id')).to.deep.equal(expectedResult);
+    });
+
     it('should return "simple_query_string" for $sqs with default_operator "or" by default', () => {
       const query = {
         $sqs: {


### PR DESCRIPTION
# Summary:

> This pull request introduces a small but important change to the `function $and` in the `lib/utils/parse-query.js` file. The change enhances query parsing by adding separate handling for non-array sections.

* [`lib/utils/parse-query.js`](diffhunk://#diff-1d249570baac1d6453886a2abed6e9b94b69619fb3aada5e74a3c7ef75b3dd21R66-L73): Updated the `function $and` to differentiate between array and non-array sections when processing parsed query objects, ensuring non-array sections are assigned directly instead of being pushed into an array.

# Task(s):

[[🐞SENTRY ] Bug: Not able to search a lead by entering the lead details in the "search lead" field.](https://app.asana.com/1/434866962028513/project/1206407507151849/task/1207276738152106?focus=true)

# Related PRs:

