### PR TITLE
refactor: added max size incase of paginate:false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.0.2-es-paginate-false-1.0](https://github.com/refrens/feathers-esx/compare/1.0.2-es-paginate-false.0...1.0.2-es-paginate-false-1.0) (2026-02-02)
+
 ## [1.0.2-es-paginate-false.0](https://github.com/refrens/feathers-esx/compare/1.0.1...1.0.2-es-paginate-false.0) (2026-02-02)
 
 ## 1.0.1 (2025-06-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.0.2-es-paginate-false.0](https://github.com/refrens/feathers-esx/compare/1.0.1...1.0.2-es-paginate-false.0) (2026-02-02)
+
 ## 1.0.1 (2025-06-25)
 
 

--- a/lib/core/find.js
+++ b/lib/core/find.js
@@ -6,7 +6,7 @@ function find(service, params) {
   const findParams = {
     _source: filters.$select,
     from: filters.$skip,
-    size: filters.$limit,
+    size: paginate === false ? filters.$limit || 10000 : filters.$limit, // Default max size to 10k if paginate is false
     sort: filters.$sort,
     body: {
       query: esQuery ? { bool: esQuery } : undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@refrens/feathers-esx",
-  "version": "1.0.2-es-paginate-false.0",
+  "version": "1.0.2-es-paginate-false-1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@refrens/feathers-esx",
-  "version": "1.0.1",
+  "version": "1.0.2-es-paginate-false.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refrens/feathers-esx",
-  "version": "1.0.2-es-paginate-false.0",
+  "version": "1.0.2-es-paginate-false-1.0",
   "description": "Refrens fork of feathers-elasticsearch with fixes and extensions",
   "main": "lib/",
   "types": "types",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refrens/feathers-esx",
-  "version": "1.0.1",
+  "version": "1.0.2-es-paginate-false.0",
   "description": "Refrens fork of feathers-elasticsearch with fixes and extensions",
   "main": "lib/",
   "types": "types",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide details and review
the requirements below.

Please provide a appropirate title to the pr. mostly it should be same as title of the task.
Open a draft pr, if you are opening it for asking help.

Please remove sections here if not applicable.
-->

### Summary
This pull request makes a small change to the `find` function in `lib/core/find.js` to improve how the maximum number of results is handled when pagination is disabled.

* When `paginate` is set to `false`, the `size` parameter now defaults to `filters.$limit` if specified, or to `10000` otherwise, ensuring a sensible maximum result size.
<!-- Please provide a summary of the change here. -->

### Task
[BUG: Duplicate Clients Are Created After Bulk Uploading Documents](https://app.asana.com/1/434866962028513/project/1206407507151849/task/1212747090024511?focus=true)
<!-- Please provide task/issue link. -->

### Related PR(s)

- <!-- Please provide affected area(s) of the code/product. -->

### Screenshots

<!-- Please provide screenshots of new/affected pages/views. -->

<!-- If any breaking change add a section -->
